### PR TITLE
Fix code scanning alert no. 4: Reflected server-side cross-site scripting

### DIFF
--- a/orch/main.py
+++ b/orch/main.py
@@ -1,4 +1,5 @@
 from flask import Flask, redirect, request, Response
+import html
 import requests
 
 app = Flask(__name__)
@@ -95,7 +96,8 @@ def proxy(pid, path):
                 for (name, value) in resp.raw.headers.items()
                 if name.lower() not in excluded_headers
             ]
-            response = Response(resp.content, resp.status_code, headers)
+            escaped_content = html.escape(resp.content.decode('utf-8'))
+            response = Response(escaped_content, resp.status_code, headers)
             return response
         elif request.method == "POST":
             resp = requests.post(


### PR DESCRIPTION
Fixes [https://github.com/EuskadiTech/Galileo/security/code-scanning/4](https://github.com/EuskadiTech/Galileo/security/code-scanning/4)

To fix the problem, we need to ensure that any user-provided input is properly sanitized or escaped before being included in the response. In this case, we should escape the content of the response before returning it to the client. The `html.escape()` function from the standard library can be used to escape the response content to prevent XSS attacks.

We will modify the code to use `html.escape()` on the response content before returning it. This change will be made in the `proxy` function where the response is constructed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
