### PR TITLE
Potential fix for code scanning alert no. 27: Uncontrolled data used in path expression

### DIFF
--- a/modules/Admin/views.py
+++ b/modules/Admin/views.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, send_file, render_template, url_for, redirect, make_response
+from werkzeug.utils import secure_filename
 from random import randint
 from ..Personas.localutils import PersonAuth, with_auth
 from ..Personas.models import DB_PERSONAS
@@ -92,7 +93,8 @@ def filesupload(user, path):
     if request.method == "POST":
         folder = full_path
         file = request.files["Archivo"]
-        file.save(os.path.join(folder, file.filename))
+        filename = secure_filename(file.filename)
+        file.save(os.path.join(folder, filename))
         return redirect(url_for("Admin.files", path = path))
     return render_template("admin/filesupload.html", path=path)
 


### PR DESCRIPTION
Potential fix for [https://github.com/EuskadiTech/Galileo/security/code-scanning/27](https://github.com/EuskadiTech/Galileo/security/code-scanning/27)

To fix the problem, we need to sanitize the `file.filename` to ensure it does not contain any malicious characters or patterns that could lead to path traversal vulnerabilities. The `werkzeug.utils.secure_filename` function is a suitable choice for this purpose as it removes any special characters from the filename, making it safe to use in file paths.

- Import the `secure_filename` function from `werkzeug.utils`.
- Use `secure_filename` to sanitize `file.filename` before using it in the `os.path.join` operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
