### PR TITLE
Potential fix for code scanning alert no. 45: Reflected server-side cross-site scripting

### DIFF
--- a/modules/AutoModule/localutils.py
+++ b/modules/AutoModule/localutils.py
@@ -7,7 +7,7 @@ from utils import USERDATA_DIR, check_path
 from glob import glob
 from uuid import uuid4
 import json
-
+import re
 
 class ModelView:
     def __init__(
@@ -190,6 +190,9 @@ class ModelView:
 
         @self.app.route(f"/api/{tablename}/<rid>/edit", methods=["POST"])
         @with_api_auth(f"{tablename}:update")
+            # Only allow alphanumeric, dash, and underscore in ids
+            if not re.match(r'^[A-Za-z0-9_-]+$', rid):
+                return {"status": "error", "message": "Invalid ID"}, 400
         def api__update(rid):
             item = model.get_by_id(str(rid))
             inp = {}


### PR DESCRIPTION
Potential fix for [https://github.com/EuskadiTech/Galileo/security/code-scanning/45](https://github.com/EuskadiTech/Galileo/security/code-scanning/45)

The best way to fix this issue is to sanitize or validate the `rid` parameter before returning it to the user in any response. Since `rid` is expected (from its usage as a database record ID, generated with `uuid4().split('-')[0]`) to be a string like a short UUID segment or similar, we should restrict it to safe characters (e.g., alphanumeric, possibly with some dashes or underscores). The most robust fix is to validate `rid` using a regular expression to only allow specific characters (such as `[A-Za-z0-9_-]+`). This preserves existing functionality and ensures that user-provided values cannot inject HTML or JavaScript in downstream consumers.

The changes needed are:
- Just before returning the JSON, validate or sanitize the `rid` value. Raise an error (or use a default value) if it does not conform to the expected format.
- Add an import for the `re` module if it is not already imported, to support this validation.

All changes should be made within the function body in `modules/AutoModule/localutils.py` where `api__update` is defined (lines 193-233), with an import at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
