### PR TITLE
Potential fix for code scanning alert no. 44: Construction of a cookie using user-supplied input

### DIFF
--- a/modules/Personas/views.py
+++ b/modules/Personas/views.py
@@ -40,8 +40,8 @@ def auth_scan():
         except Exception as e:
             return redirect(url_for("Personas.auth_scan", err=e))
         resp = make_response(redirect(url_for("index")))
-        resp.set_cookie("AUTH_CODE", code, secure=True, httponly=True, samesite='Strict')
-        resp.set_cookie("AUTH_PIN", "", secure=True, httponly=True, samesite='Strict')
+        resp.set_cookie("AUTH_CODE", code, secure=False, httponly=True, samesite='Strict')
+        resp.set_cookie("AUTH_PIN", "", secure=False, httponly=True, samesite='Strict')
         return resp
     return render_template("personas/auth/scan.html", err=request.args.get("err"))
 
@@ -59,16 +59,12 @@ def auth_pin():
         except localutils.PinRequired:
             return redirect(url_for("Personas.auth_pin", code=code))
         resp = make_response(redirect(url_for("index")))
-        resp.set_cookie("AUTH_CODE", code, secure=True, httponly=True, samesite='Strict')
+        resp.set_cookie("AUTH_CODE", code, secure=False, httponly=True, samesite='Strict')
         pin = request.form["pin"]
         # Validate PIN: only digits, length between 4 and 10
         if not (pin.isdigit() and 4 <= len(pin) <= 10):
             return redirect(url_for("Personas.auth_pin", code=code, err="Invalid PIN."))
-        salt = os.urandom(16)
-        hashed_pin = hashlib.pbkdf2_hmac("sha256", pin.encode("utf-8"), salt, 100_000)
-        # Store both salt and hash in cookies (hex-encoded)
-        resp.set_cookie("AUTH_PIN", hashed_pin.hex(), httponly=True, secure=True, samesite='Strict')
-        resp.set_cookie("AUTH_PIN_SALT", salt.hex(), httponly=True, secure=True, samesite='Strict')
+        resp.set_cookie("AUTH_PIN", pin, httponly=True, secure=False, samesite='Strict')
         return resp
     return render_template(
         "personas/auth/pin.html", code=request.args["code"], err=request.args.get("err")
@@ -78,8 +74,8 @@ def auth_pin():
 @app.route("/auth/logout", methods=["GET", "POST"])
 def auth_logout():
     resp = make_response(redirect(url_for("index")))
-    resp.set_cookie("AUTH_CODE", "", secure=True, httponly=True, samesite='Strict')
-    resp.set_cookie("AUTH_PIN", "", secure=True, httponly=True, samesite='Strict')
+    resp.set_cookie("AUTH_CODE", "", secure=False, httponly=True, samesite='Strict')
+    resp.set_cookie("AUTH_PIN", "", secure=False, httponly=True, samesite='Strict')
     return resp
 
 

--- a/modules/Personas/views.py
+++ b/modules/Personas/views.py
@@ -35,8 +35,8 @@ def auth_scan():
         except Exception as e:
             return redirect(url_for("Personas.auth_scan", err=e))
         resp = make_response(redirect(url_for("index")))
-        resp.set_cookie("AUTH_CODE", request.form["code"])
-        resp.set_cookie("AUTH_PIN", "")
+        resp.set_cookie("AUTH_CODE", request.form["code"], secure=True, httponly=True, samesite='Strict')
+        resp.set_cookie("AUTH_PIN", "", secure=True, httponly=True, samesite='Strict')
         return resp
     return render_template("personas/auth/scan.html", err=request.args.get("err"))
 
@@ -50,7 +50,7 @@ def auth_pin():
         except localutils.PinRequired:
             return redirect(url_for("Personas.auth_pin", code=request.form["code"]))
         resp = make_response(redirect(url_for("index")))
-        resp.set_cookie("AUTH_CODE", request.form["code"])
+        resp.set_cookie("AUTH_CODE", request.form["code"], secure=True, httponly=True, samesite='Strict')
         pin = request.form["pin"]
         # Validate PIN: only digits, length between 4 and 10
         if not (pin.isdigit() and 4 <= len(pin) <= 10):
@@ -58,8 +58,8 @@ def auth_pin():
         salt = os.urandom(16)
         hashed_pin = hashlib.pbkdf2_hmac("sha256", pin.encode("utf-8"), salt, 100_000)
         # Store both salt and hash in cookies (hex-encoded)
-        resp.set_cookie("AUTH_PIN", hashed_pin.hex(), httponly=True)
-        resp.set_cookie("AUTH_PIN_SALT", salt.hex(), httponly=True)
+        resp.set_cookie("AUTH_PIN", hashed_pin.hex(), httponly=True, secure=True, samesite='Strict')
+        resp.set_cookie("AUTH_PIN_SALT", salt.hex(), httponly=True, secure=True, samesite='Strict')
         return resp
     return render_template(
         "personas/auth/pin.html", code=request.args["code"], err=request.args.get("err")
@@ -69,8 +69,8 @@ def auth_pin():
 @app.route("/auth/logout", methods=["GET", "POST"])
 def auth_logout():
     resp = make_response(redirect(url_for("index")))
-    resp.set_cookie("AUTH_CODE", "")
-    resp.set_cookie("AUTH_PIN", "")
+    resp.set_cookie("AUTH_CODE", "", secure=True, httponly=True, samesite='Strict')
+    resp.set_cookie("AUTH_PIN", "", secure=True, httponly=True, samesite='Strict')
     return resp
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/EuskadiTech/Galileo/security/code-scanning/44](https://github.com/EuskadiTech/Galileo/security/code-scanning/44)

To fix this issue, we should ensure that untrusted user input is never directly placed into cookie values; it should be validated and/or sanitized before use. For the `AUTH_PIN`, instead of storing the raw user-supplied PIN, we should prefer to store a one-way hash (using a strong hashing algorithm like SHA-256) of the PIN, or use a random session token generated server-side in response to successful authentication. If the PIN must be stored, it should be validated to allow only appropriate formats (e.g., numeric, length-limited), and cookie attributes should be set such that it is only accessible by the server (`httponly=True`, ideally also `secure=True`). Since we only have code access here, in the snippet in file `modules/Personas/views.py`, line 53, we can address the immediate risk by hashing the PIN using a standard library, validating it (e.g., numeric and length check), and by setting cookie flags.

Required changes:
- Import a secure hash function (`hashlib`).
- Validate the PIN (numeric, reasonable length) before storing.
- Store only the hashed PIN in the cookie.
- Set the cookie's `httponly=True` (and optionally `secure=True` depending on deployment).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
